### PR TITLE
Fix typo in order overview

### DIFF
--- a/resources/views/cp/orders/show.blade.php
+++ b/resources/views/cp/orders/show.blade.php
@@ -99,7 +99,7 @@
                     <td>{{ $item->quantity }}</td>
                 </tr>
                 <tr>
-                    <th class="pl-2 py-1 w-1/4">S{{ __('butik::cp.summed_price') }}</th>
+                    <th class="pl-2 py-1 w-1/4">{{ __('butik::cp.summed_price') }}</th>
                     <td>{{ $item->totalPrice }}</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
In the backend is a typo. I suppose that this addional "S" is not required