### PR TITLE
Fix issue with the translation

### DIFF
--- a/resources/lang/en/web.php
+++ b/resources/lang/en/web.php
@@ -30,7 +30,7 @@ return [
     'link_price'               => 'Link price',
     'link_invalid'             => 'This link is not valid anymore.',
     'email'                    => 'Email',
-    'email_sent'               => 'A confirmation email will be sent to :mail',
+    'email_sent'               => 'A confirmation email will be sent to :email',
     'method'                   => 'Method',
     'minimum'                  => 'Minimum',
     'name'                     => 'Name',


### PR DESCRIPTION
# Whats wrong?
The translation file misses a "e" in the placeholder.
That results in a missing replacement of the email in the receipt.

# Whats done?
Changed the placeholder from :mail to :email 