### PR TITLE
Export path correction for mails

### DIFF
--- a/src/StatamicButikServiceProvider.php
+++ b/src/StatamicButikServiceProvider.php
@@ -154,7 +154,7 @@ class StatamicButikServiceProvider extends AddonServiceProvider
 
             // Views
             $this->publishes([
-                __DIR__.'/../resources/views/email' => resource_path('views/vendor/butik/emails'),
+                __DIR__.'/../resources/views/email' => resource_path('views/vendor/butik/email'),
             ], 'butik-views');
             $this->publishes([
                 __DIR__.'/../resources/views/web' => resource_path('views/vendor/butik/web'),


### PR DESCRIPTION
The path for the view resources export for mails is not correct. 
This causes the problem, that you might not be able to adapt the customer mail.

Changed the export path from "emails" to "email" - so use can change the email layouts.