### PR TITLE
Fix product permissions. Closes #137

### DIFF
--- a/src/Policies/VariantPolicy.php
+++ b/src/Policies/VariantPolicy.php
@@ -12,31 +12,31 @@ class VariantPolicy
 
     public function index(User $user)
     {
-        return $user->hasPermission('edit products');
+        return $user->hasPermission('edit products entries');
     }
 
     public function create(User $user)
     {
-        return $user->hasPermission('edit products');
+        return $user->hasPermission('edit products entries');
     }
 
     public function store(User $user)
     {
-        return $user->hasPermission('edit products');
+        return $user->hasPermission('edit products entries');
     }
 
     public function edit($user, Variant $variant)
     {
-        return $user->hasPermission('edit products');
+        return $user->hasPermission('edit products entries');
     }
 
     public function update(User $user, $variant)
     {
-        return $user->hasPermission('edit products');
+        return $user->hasPermission('edit products entries');
     }
 
     public function delete(User $user, Variant $variant)
     {
-        return $user->hasPermission('edit products');
+        return $user->hasPermission('edit products entries');
     }
 }

--- a/src/StatamicButikServiceProvider.php
+++ b/src/StatamicButikServiceProvider.php
@@ -278,7 +278,7 @@ class StatamicButikServiceProvider extends AddonServiceProvider
             // Products
             $nav->create(ucfirst(__('butik::cp.product_plural')))
                 ->section('Butik')
-                ->can(auth()->user()->can('view products'))
+                ->can(auth()->user()->can('view products entries'))
                 ->route('collections.show', 'products')
                 ->icon('tags');
 


### PR DESCRIPTION
We did check our permissions with `action products` syntax. 

By using butik collections for products, the syntax did change to `action products entries`.

This fixes #137 