### PR TITLE
Created configuration option for product route.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -67,6 +67,7 @@ return [
     'category_route_active' => true, // default: true. Set to false to deactive this route.
 
     'route_shop-prefix'       => 'shop',                       // yourshop.com/shop/
+    'route_product'           => '{product}/{variant?}',       // yourshop.com/shop/xxxxx
     'route_cart'              => 'cart',                       // yourshop.com/shop/cart
     'route_category'          => 'category/{category}',         // yourshop.com/shop/category/xxxxx
     'route_checkout-delivery' => 'checkout/delivery',           // yourshop.com/shop/checkout/delivery

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,7 @@ Route::namespace('\Jonassiewertsen\StatamicButik\Http\Controllers\Web')
         }
 
         if (config('butik.product_route_active')) {
-            Route::get('{product}/{variant?}', 'ShopController@show')
+            Route::get(config('butik.route_product'), 'ShopController@show')
                 ->name('shop.product');
         }
     });

--- a/src/Http/Models/Product.php
+++ b/src/Http/Models/Product.php
@@ -235,9 +235,7 @@ class Product
 
     public function showUrl($slug): string
     {
-        $route = locale_url().'/'.config('butik.route_shop-prefix').'/'.$slug;
-
-        return (string) Str::of($route)->start('/');
+        return route('butik.shop.product', ['product' => $slug], false);
     }
 
     public function __get(string $property)

--- a/src/Http/Models/Variant.php
+++ b/src/Http/Models/Variant.php
@@ -130,9 +130,7 @@ class Variant extends ButikModel
      */
     public function getShowUrlAttribute()
     {
-        $route = "{$this->shopRoute()}/{$this->product_slug}/{$this->original_title}";
-
-        return Str::of($route)->start('/');
+        return route('butik.shop.product', ['product' => $this->product_slug, 'variant' => $this->original_title], false);
     }
 
     /**

--- a/src/Http/Models/Variant.php
+++ b/src/Http/Models/Variant.php
@@ -129,7 +129,11 @@ class Variant extends ButikModel
      */
     public function getShowUrlAttribute()
     {
-        return route('butik.shop.product', ['product' => $this->product_slug, 'variant' => $this->original_title], false);
+        return route('butik.shop.product', [
+            'product' => $this->product_slug,
+            'variant' => $this->original_title],
+            false
+        );
     }
 
     /**

--- a/src/Http/Models/Variant.php
+++ b/src/Http/Models/Variant.php
@@ -4,7 +4,6 @@ namespace Jonassiewertsen\StatamicButik\Http\Models;
 
 use Facades\Jonassiewertsen\StatamicButik\Http\Models\Product;
 use Jonassiewertsen\StatamicButik\Http\Traits\MoneyTrait;
-use Statamic\Support\Str;
 
 class Variant extends ButikModel
 {

--- a/src/Http/Models/Variant.php
+++ b/src/Http/Models/Variant.php
@@ -131,7 +131,7 @@ class Variant extends ButikModel
     {
         return route('butik.shop.product', [
             'product' => $this->product_slug,
-            'variant' => $this->original_title
+            'variant' => $this->original_title,
         ], false);
     }
 

--- a/src/Http/Models/Variant.php
+++ b/src/Http/Models/Variant.php
@@ -131,9 +131,8 @@ class Variant extends ButikModel
     {
         return route('butik.shop.product', [
             'product' => $this->product_slug,
-            'variant' => $this->original_title],
-            false
-        );
+            'variant' => $this->original_title
+        ], false);
     }
 
     /**

--- a/tests/Unit/VariantTest.php
+++ b/tests/Unit/VariantTest.php
@@ -53,7 +53,7 @@ class VariantTest extends TestCase
     public function it_has_a_show_url()
     {
         $this->assertEquals(
-            "/shop/{$this->product->slug}/{$this->variant->original_title}",
+            "/shop/{$this->product->slug}/" . rawurlencode($this->variant->original_title),
             $this->variant->show_url
         );
     }

--- a/tests/Unit/VariantTest.php
+++ b/tests/Unit/VariantTest.php
@@ -53,7 +53,7 @@ class VariantTest extends TestCase
     public function it_has_a_show_url()
     {
         $this->assertEquals(
-            "/shop/{$this->product->slug}/" . rawurlencode($this->variant->original_title),
+            "/shop/{$this->product->slug}/".rawurlencode($this->variant->original_title),
             $this->variant->show_url
         );
     }


### PR DESCRIPTION
Added configuration option to enable users to change the Product route.

Apart from customizing the Product URL this will also enable users to have an empty `route_shop-prefix` and still be able to have other dynamic root URLs (like a Statamic Page) on their site. This was not possible earlier since the Product route swallowed everything.

I hope I didn't miss any other instance where the Product/Variant route was hard-coded.