### PR TITLE
Add property to event, otherwise the event will fail

### DIFF
--- a/src/Events/OrderCreated.php
+++ b/src/Events/OrderCreated.php
@@ -9,6 +9,8 @@ class OrderCreated
 {
     use SerializesModels;
 
+    public Order $order;
+
     public function __construct(Order $order)
     {
         $this->order = $order;


### PR DESCRIPTION
It occurs that the order create event is missing the property 

```php
public Order $order;
```

which results in an exception.