### PR TITLE
Delete orders through the control panel

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -50,6 +50,18 @@ return [
     'currency_delimiter' => ',',
 
     /**
+     * Oders settings.
+     *
+     * You can define how orders can be deleted. Can they at all, only in production or via the UI
+     * if the user has gotten permission to do so.
+     *
+     * never: Safety first. Orders can never be delete.
+     * development: As long as not in production, you can delete orders.
+     * users: Orders can be deleted in production as well, if permission has been given.
+     */
+    'orders_deletable'  => env('BUTIK_ORDERS_DELETABLE', 'development'),
+
+    /**
      * WIDGETS.
      *
      * Settings for your dashboard widgets

--- a/resources/js/components/orders/Listing.vue
+++ b/resources/js/components/orders/Listing.vue
@@ -44,8 +44,8 @@
 
                     <data-list-table
                         v-if="items.length"
-                        :allow-bulk-actions="true"
                         :loading="loading"
+                        :allow-bulk-actions="true"
                         :allow-column-picker="true"
                         :column-preferences-key="preferencesKey('columns')"
                         @sorted="sorted"

--- a/resources/lang/de/cp.php
+++ b/resources/lang/de/cp.php
@@ -48,6 +48,8 @@ return [
     'permission_show_orders_description'      => 'Die Berechtigung geben, um die Details aller vorhandenen Bestellungen einzusehen.',
     'permission_update_orders'                => 'Bestellungen aktualisieren',
     'permission_update_orders_description'    => 'Die Berechtigung geben, um Bestellungen zu bearbeiten.',
+    'permission_delete_orders'                => 'Bestellungen löschen',
+    'permission_delete_orders_description'    => 'Die Berechtigung geben, um Bestellungen zu löschen.',
     'permission_view_products'                => 'Produkte anzeigen',
     'permission_view_products_description'    => 'Die Berechtigung geben, um alle Produkte anzuzeigen.',
     'permission_edit_products'                => 'Produkte bearbeiten',

--- a/resources/lang/en/cp.php
+++ b/resources/lang/en/cp.php
@@ -48,6 +48,8 @@ return [
     'permission_show_orders_description'      => 'Grants access to see the order details',
     'permission_update_orders'                => 'Update Orders',
     'permission_update_orders_description'    => 'Grants access to edit existing orders',
+    'permission_delete_orders'                => 'Delete Orders',
+    'permission_delete_orders_description'    => 'Grants access to delete orders',
     'permission_view_products'                => 'View Products',
     'permission_view_products_description'    => 'Grants access to view all existing products',
     'permission_edit_products'                => 'Edit Products',

--- a/resources/views/cp/orders/index.blade.php
+++ b/resources/views/cp/orders/index.blade.php
@@ -11,6 +11,8 @@
     <butik-order-list
         show-route="{{ cp_route('butik.orders.show', 'XXX') }}"
         orders-request-url="{{ cp_route('butik.api.orders.index') }}"
+        run-action-url="{{ cp_route('butik.actions.orders.run') }}"
+        bulk-actions-url="{{ cp_route('butik.actions.orders.bulk') }}"
         :filters="{{ json_encode($filters) }}"
         v-cloak
     >

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -63,6 +63,12 @@ Route::namespace('\Jonassiewertsen\StatamicButik\Http\Controllers\CP')
             ]);
         });
 
+        // Actions for individual listings as used by fx orders.
+        Route::name('actions.')->prefix('actions')->group(function () {
+            Route::post('orders', 'OrderActionController@run')->name('orders.run');
+            Route::get('orders', 'OrderActionController@bulkActions')->name('orders.bulk');
+        });
+
         // API Resource Controller
         Route::prefix('api')->name('api.')->group(function () {
             Route::get('orders/get', 'Api\OrdersController@index')->name('orders.index');

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Jonassiewertsen\StatamicButik\Actions;
+
+use Jonassiewertsen\StatamicButik\Http\Models\Order;
+use Statamic\Actions\Action;
+use Statamic\Contracts\Auth\User as UserContract;
+
+class Delete extends Action
+{
+    protected $dangerous = true;
+
+    public static function title()
+    {
+        return __('Delete');
+    }
+
+    public function visibleTo($item)
+    {
+        return$item instanceof Order;
+    }
+
+    public function authorize($user, $item)
+    {
+        return true; // TODO: Authorize the delete action
+
+        if ($item instanceof UserContract && $user->id() === $item->id()) {
+            return false;
+        }
+
+        return $user->can('delete', $item);
+    }
+
+    public function buttonText()
+    {
+        /** @translation */
+        return 'Delete|Delete :count orders?';
+    }
+
+    public function confirmationText()
+    {
+        /** @translation */
+        return 'Are you sure you want to want to delete this order?|Are you sure you want to delete these :count orders?';
+    }
+
+    public function run($items, $values)
+    {
+        // TODO: Add a delete methods
+        // $items->each->delete();
+    }
+}

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -51,6 +51,6 @@ class Delete extends Action
 
     public function run($items, $values)
     {
-         $items->each->delete();
+        $items->each->delete();
     }
 }

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -2,6 +2,7 @@
 
 namespace Jonassiewertsen\StatamicButik\Actions;
 
+use Jonassiewertsen\StatamicButik\Exceptions\ButikConfigException;
 use Jonassiewertsen\StatamicButik\Http\Models\Order;
 use Statamic\Actions\Action;
 
@@ -16,12 +17,24 @@ class Delete extends Action
 
     public function visibleTo($item)
     {
-        return$item instanceof Order;
+        return $item instanceof Order;
     }
 
-    public function authorize($user, $item)
+    public function authorize($user, $item): bool
     {
-        return $user->can('delete', $item);
+        if (config('butik.orders_deletable') === 'users') {
+            return $user->can('delete', $item);
+        }
+
+        if (config('butik.orders_deletable') === 'never') {
+            return false;
+        }
+
+        if (config('butik.orders_deletable') === 'development') {
+            return config('app.env') !== 'production';
+        }
+
+        throw new ButikConfigException('Make sure to set your butik orders_deletable config to \'never\', \'development\' or \'user\'. Yours is: '.config('butik.orders_deletable'));
     }
 
     public function buttonText()

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -4,7 +4,6 @@ namespace Jonassiewertsen\StatamicButik\Actions;
 
 use Jonassiewertsen\StatamicButik\Http\Models\Order;
 use Statamic\Actions\Action;
-use Statamic\Contracts\Auth\User as UserContract;
 
 class Delete extends Action
 {
@@ -22,12 +21,6 @@ class Delete extends Action
 
     public function authorize($user, $item)
     {
-        return true; // TODO: Authorize the delete action
-
-        if ($item instanceof UserContract && $user->id() === $item->id()) {
-            return false;
-        }
-
         return $user->can('delete', $item);
     }
 

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -45,7 +45,6 @@ class Delete extends Action
 
     public function run($items, $values)
     {
-        // TODO: Add a delete methods
-        // $items->each->delete();
+         $items->each->delete();
     }
 }

--- a/src/Http/Controllers/CP/OrderActionController.php
+++ b/src/Http/Controllers/CP/OrderActionController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jonassiewertsen\StatamicButik\Http\Controllers\CP;
+
+use Jonassiewertsen\StatamicButik\Http\Models\Order;
+use Statamic\Http\Controllers\CP\ActionController;
+
+class OrderActionController extends ActionController
+{
+    protected function getSelectedItems($items, $context)
+    {
+        return $items->map(function ($item) {
+            return Order::find($item);
+        });
+    }
+}

--- a/src/Http/Resources/OrderResource.php
+++ b/src/Http/Resources/OrderResource.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Carbon;
 use Jonassiewertsen\StatamicButik\Blueprints\OrderBlueprint;
 use Jonassiewertsen\StatamicButik\Http\Models\Order;
+use Statamic\Facades\Action;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;
 
@@ -58,6 +59,7 @@ class OrderResource extends ResourceCollection
 
                     'viewable' => User::current()->can('view orders', $order),
                     'editable' => User::current()->can('update orders', $order),
+                    'actions'  => Action::for($order),
                 ];
             }),
 

--- a/src/Policies/OrderPolicy.php
+++ b/src/Policies/OrderPolicy.php
@@ -16,6 +16,11 @@ class OrderPolicy extends Policies
 
     public function update($user, $order)
     {
-        return $this->hasPermission($user, 'update products');
+        return $this->hasPermission($user, 'update orders');
+    }
+
+    public function delete($user, $order)
+    {
+        return $this->hasPermission($user, 'delete orders');
     }
 }

--- a/src/StatamicButikServiceProvider.php
+++ b/src/StatamicButikServiceProvider.php
@@ -224,6 +224,9 @@ class StatamicButikServiceProvider extends AddonServiceProvider
                             Permission::make('update orders')
                                 ->label(__('butik::cp.permission_update_orders'))
                                 ->description(__('butik::cp.permission_update_orders_description')),
+                            Permission::make('delete orders')
+                                ->label(__('butik::cp.permission_delete_orders'))
+                                ->description(__('butik::cp.permission_delete_orders_description')),
                         ]);
                 });
                 Permission::register('view shippings', function ($permission) {

--- a/src/StatamicButikServiceProvider.php
+++ b/src/StatamicButikServiceProvider.php
@@ -28,6 +28,10 @@ class StatamicButikServiceProvider extends AddonServiceProvider
 {
     protected $publishAfterInstall = false;
 
+    protected $actions = [
+        \Jonassiewertsen\StatamicButik\Actions\Delete::class,
+    ];
+
     protected $commands = [
         \Jonassiewertsen\StatamicButik\Commands\SetUpButik::class,
         \Jonassiewertsen\StatamicButik\Commands\MakeShipping::class,


### PR DESCRIPTION
This does make it possible to delete orders. 

- [x] Add the delete action to the orders listing
- [x] Orders can be deleted 
- [x] Add config options as described in #143 
- [x] Only authorized users can delete orders
- [x] The delete button does only show if allowed to delete orders
- [x] Update the docs

Closes #143 